### PR TITLE
remove conflicting css selector

### DIFF
--- a/app/assets/stylesheets/reports.css.less
+++ b/app/assets/stylesheets/reports.css.less
@@ -9,7 +9,7 @@
   display: none;
 }
 
-.row > div {
+div.filter-heading {
   padding-left: 15px;
 }
 

--- a/app/views/change/_filter_panel.html.erb
+++ b/app/views/change/_filter_panel.html.erb
@@ -6,7 +6,7 @@
     <div class="row">
       <div class="btn-group mixer-buttons system-filter-buttons col-md-2">
         <div class="row">
-          <div>
+          <div class="filter-heading">
             <strong>System</strong>
           </div>
           <div class="col-md-9">
@@ -28,7 +28,7 @@
       <div class="row">
         <div class="btn-group mixer-buttons product-filter-buttons col-md-2">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>Product</strong>
             </div>
             <div class="col-md-9">
@@ -49,7 +49,7 @@
       <div class="row">
         <div class="btn-group mixer-buttons priority-filter-buttons col-md-2">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>Priority</strong>
             </div>
             <div class="col-md-9">
@@ -65,7 +65,7 @@
       <div class="row">
         <div class="btn-group mixer-buttons status-filter-buttons col-md-2">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>Status</strong>
             </div>
             <div class="col-md-9">
@@ -81,7 +81,7 @@
       <div class="row">
         <div class="btn-group mixer-buttons status-filter-buttons col-md-2">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>Impact</strong>
             </div>
             <div class="col-md-9">
@@ -97,7 +97,7 @@
       <div class="row">
         <div class="btn-group mixer-buttons status-filter-buttons col-md-2">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>Change_Type</strong>
             </div>
             <div class="col-md-9">
@@ -113,7 +113,7 @@
       <div class="row">
         <div class="btn-group mixer-buttons system-filter-buttons col-md-2">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>User</strong>
             </div>
             <div class="col-md-9">
@@ -129,7 +129,7 @@
       <div class="row">
         <div class="btn-group mixer-buttons col-md-12">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>Sort</strong>
             </div>
             <div class="col-md-12">
@@ -144,7 +144,7 @@
       <div class="row">
         <div class="select-control col-md-12">
           <div class="row">
-            <div>
+            <div class="filter-heading">
               <strong>Select All</strong>
             </div>
             <div class="col-md-12">


### PR DESCRIPTION
.row > div was to broad of a selector and it had unintended
consequences. the dashboard records per page filter, which happens to
match the same css pattern was being pushed to the right by 15px.